### PR TITLE
Fixed wrong delay for recurring timer

### DIFF
--- a/timer.lua
+++ b/timer.lua
@@ -229,7 +229,7 @@ function timer:enterFrame( event )
 							entry._iterations = iterations - 1
 						end
 
-						local fireTime = currentTime + entry._delay
+						local fireTime = entry._time + entry._delay
 						entry._time = fireTime
 						timer._insert( timer, entry, fireTime )
 					end


### PR DESCRIPTION
Example ([source](https://habr.com/post/422443/))
```
local timeout = 1000
socket = require "socket"
local start_time = socket.gettime() * 1000
local good_time = 0
local bad_time = 0

timer.performWithDelay(timeout, function(event)
  bad_time = event.count
  local bad_delta = (socket.gettime() * 1000 - start_time) - (bad_time * timeout)
  print("Bad tick: " .. bad_time, "Delta: " .. bad_delta)
end, 0)

timer.performWithDelay(1, function(event)
  local new_time = socket.gettime() * 1000
  local total_time = new_time - start_time
  local num = math.floor(total_time / timeout)
  if num > good_time then
    good_time = num
    local good_delta = (socket.gettime() * 1000 - start_time) - (good_time * timeout)
    print("Good tick: " .. good_time, "Delta: " .. good_delta)
  end
end, 0)
```

Issue: the more iterations passed (in this example 1 iteration = 1 second), the more is difference between "good" and "bad" one version. 
Good versions follows system clock - 60 triggers of callback per minute
Wrong versions loses precise with each second - for example you can see 119 triggers per 2 minutes (depends on fps)

Therefore, this fix is intended to improve the accuracy of long repeating timers