### PR TITLE
Fix error in determining whatToCancel type

### DIFF
--- a/timer.lua
+++ b/timer.lua
@@ -63,7 +63,7 @@ function timer.cancel( whatToCancel )
 	-- Since pausing timers removes them from runlist, it means that both runlist
 	-- and pausedTimers must be checked when cancelling timers using a tag.
 	local list = {}
-	if "table" == whatToCancel then
+	if "table" == t then
 		list[1] = whatToCancel
 	else
 		local runlist = timer._runlist


### PR DESCRIPTION
Previous PR accidentally included a mistake where the type of ```whatToCancel``` was supposed to be compared to see if the type was "table", but instead it it was directly comparing against the table.

The error is now fixed and the timer should work flawlessly again.